### PR TITLE
Fix activity log header inclusion

### DIFF
--- a/pages/api/activity-log.ts
+++ b/pages/api/activity-log.ts
@@ -21,7 +21,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const data = response.data.values || [];
 
-    const activities = data.slice(0).map(row => ({
+    // Skip the header row if present
+    const activities = data.slice(1).map(row => ({
       timestamp: row[0],
       eventType: row[1],
       user: row[2],


### PR DESCRIPTION
## Summary
- ensure activity log API skips the header row when returning entries

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc --noEmit` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_684af9455e30832f9c22365b9cf57d4a